### PR TITLE
페이지 네이션 아이콘 작업 및 th 정렬, table영역  스크롤 적용

### DIFF
--- a/src/features/leaderboard/LeaderBoard.module.css
+++ b/src/features/leaderboard/LeaderBoard.module.css
@@ -1,5 +1,4 @@
 .wrapper {
-  padding: 2rem;
   display: flex;
   flex-direction: column;
   gap: 2rem;
@@ -16,10 +15,14 @@
   text-align: center;
 }
 
-.table {
-  width: 100%;
+.tableWrapper {
   height: 700px;
   overflow-y: auto;
+  width: 100%;
+}
+
+.table {
+  width: 100%;
 }
 
 .table_head,
@@ -35,16 +38,23 @@
   font-size: 1rem;
   font-weight: 500;
   text-align: center;
+  height: 25px;
+  vertical-align: middle;
 }
 
 .table_head th {
   background-color: #f9fafb;
   cursor: pointer;
   transition: background-color 0.3s ease;
+  width: 40px;
 }
 
 .table_head th:hover {
   background-color: #e2e8f0;
+}
+
+.long {
+  width: 100px !important;
 }
 
 .pagecount_container {
@@ -73,4 +83,62 @@
 
 .pagecount_select:hover {
   background-color: #e2e8f0;
+}
+
+.paging_container {
+  width: 500px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 0 auto;
+}
+
+.paging_btns {
+  display: flex;
+  gap: 8px;
+}
+
+.paging_btn {
+  font-weight: normal;
+  cursor: pointer;
+  width: 30px;
+  height: 30px;
+  border-radius: 5px;
+  border: 2px solid #4c9dff;
+  background-color: #fff;
+  color: #555;
+  font-size: 14px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: all 0.3s ease;
+}
+
+.paging_btn:hover {
+  background-color: #4c9dff;
+  color: white;
+  border-color: #3498db;
+}
+
+.paging_btn:disabled {
+  cursor: default;
+  background-color: #f5f5f5;
+  color: #bbb;
+  border-color: #ccc;
+}
+
+.active {
+  font-weight: bold !important;
+  background-color: #4c9dff !important;
+  color: white !important;
+  border-color: #4c9dff !important;
+  cursor: default !important;
+}
+
+.paging_btn:focus {
+  outline: none;
+}
+
+.paging_btns button:focus {
+  box-shadow: 0 0 5px rgba(76, 157, 255, 0.8);
 }

--- a/src/features/leaderboard/components/Board.tsx
+++ b/src/features/leaderboard/components/Board.tsx
@@ -37,10 +37,16 @@ const Board = () => {
       ) : (
         <>
           <PageCount count={count} setCount={setCount} />
-          <table className={styles.table}>
-            <TableHead selected={selected} order={order} onSort={handleSort} />
-            <TableBody data={paginatedData} startIndex={startIndex} />
-          </table>
+          <div className={styles.tableWrapper}>
+            <table className={styles.table}>
+              <TableHead
+                selected={selected}
+                order={order}
+                onSort={handleSort}
+              />
+              <TableBody data={paginatedData} startIndex={startIndex} />
+            </table>
+          </div>
           <PageController
             page={page}
             setPage={setPage}

--- a/src/features/leaderboard/components/PageController.tsx
+++ b/src/features/leaderboard/components/PageController.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from 'react';
+import styles from '../LeaderBoard.module.css';
+import { usePagination } from '../hooks/usePagination';
 
 type PageControllerProps = {
   page: number;
@@ -13,53 +14,48 @@ const PageController: React.FC<PageControllerProps> = ({
   totalItems,
   count,
 }) => {
-  const totalPages = Math.ceil(totalItems / count);
-
-  const pageGroup = Math.floor((page - 1) / 10);
-  const startPage = pageGroup * 10 + 1;
-  const endPage = Math.min(startPage + 9, totalPages);
-
-  const pageButtons = [];
-
-  useEffect(() => {
-    if (page > totalItems / count) setPage(totalItems / count);
-  }, [count, page, setPage, totalItems]);
-
-  for (let i = startPage; i <= endPage; i++) {
-    pageButtons.push(
-      <button
-        key={i}
-        onClick={() => setPage(i)}
-        disabled={i === page}
-        style={{
-          fontWeight: i === page ? 'bold' : 'normal',
-          cursor: i === page ? 'default' : 'pointer',
-        }}
-      >
-        {i}
-      </button>
-    );
-  }
-
-  const handlePrevGroup = () => {
-    if (startPage > 1) {
-      setPage(startPage - 1);
-    }
-  };
-
-  const handleNextGroup = () => {
-    if (endPage < totalPages) {
-      setPage(endPage + 1);
-    }
-  };
+  const {
+    pageButtons,
+    moveNextGroup,
+    movePrevGroup,
+    startPage,
+    endPage,
+    totalPages,
+  } = usePagination({
+    page,
+    setPage,
+    totalItems,
+    count,
+  });
 
   return (
-    <div>
-      <button onClick={handlePrevGroup} disabled={startPage === 1}>
+    <div className={styles.paging_container}>
+      <button
+        className={styles.paging_btn}
+        onClick={movePrevGroup}
+        disabled={startPage === 1}
+      >
         &lt;
       </button>
-      {pageButtons}
-      <button onClick={handleNextGroup} disabled={endPage === totalPages}>
+      <div className={styles.paging_btns}>
+        {pageButtons.map((btnPage) => (
+          <button
+            key={btnPage}
+            onClick={() => setPage(btnPage)}
+            disabled={btnPage === page}
+            className={`${styles.paging_btn} ${
+              btnPage === page ? styles.active : ''
+            }`}
+          >
+            {btnPage}
+          </button>
+        ))}
+      </div>
+      <button
+        className={styles.paging_btn}
+        onClick={moveNextGroup}
+        disabled={endPage === totalPages}
+      >
         &gt;
       </button>
     </div>

--- a/src/features/leaderboard/hooks/usePagination.ts
+++ b/src/features/leaderboard/hooks/usePagination.ts
@@ -1,0 +1,43 @@
+import { useEffect, useMemo } from 'react';
+
+type props = {
+  page: number;
+  setPage: React.Dispatch<React.SetStateAction<number>>;
+  totalItems: number;
+  count: number;
+};
+
+export const usePagination = ({ page, setPage, totalItems, count }: props) => {
+  const totalPages = Math.ceil(totalItems / count);
+  const pageGroup = Math.floor((page - 1) / 10);
+  const startPage = pageGroup * 10 + 1;
+  const endPage = Math.min(startPage + 9, totalPages);
+
+  const pageButtons = useMemo(() => {
+    return new Array(endPage - startPage + 1)
+      .fill(0)
+      .map((_, i) => startPage + i);
+  }, [startPage, endPage]);
+
+  const movePrevGroup = () => {
+    if (startPage > 1) setPage(startPage - 1);
+  };
+
+  const moveNextGroup = () => {
+    if (endPage < totalPages) setPage(endPage + 1);
+  };
+
+  // 10~20으로 갈 경우 페이지가 넘을 수 있음
+  useEffect(() => {
+    if (page > totalPages) setPage(totalPages);
+  }, [page, setPage, totalPages]);
+
+  return {
+    pageButtons,
+    movePrevGroup,
+    moveNextGroup,
+    startPage,
+    endPage,
+    totalPages,
+  };
+};


### PR DESCRIPTION
페이지 네이션 아이콘 작업 및 th 정렬, table영역  스크롤 적용
페이지네이션기능 커스텀 훅으로 관심사 분리 

trobule shooting : td길이 관련 배열 생성 시  count가 바뀌면 배열의 길이가 음수가 나와서 에러.
useMemo로 메모하여 사용하여 컴퍼넌트 리렌더링 시 계속 선언하는게 아니라, 캐싱하여 사용
==> 10 개씩 30페이지에서 20개씩으로 바꿔도  25페이지로 이동(20개 기준 마지막 페이지) 이후 배열을 재생성이 됨)

close #5 